### PR TITLE
Malakoff correction de deux extrémités avec une propriété, qui étaient reproduites sous forme d’épingles

### DIFF
--- a/carte_de_travail_pistes_temporaires.geojson
+++ b/carte_de_travail_pistes_temporaires.geojson
@@ -952,19 +952,6 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "Malakoff - Victor-Hugo"
-            },
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    2.30828759909,
-                    48.82355059975
-                ]
-            }
-        },
-        {
-            "type": "Feature",
-            "properties": {
                 "name": "93 - D410"
             },
             "geometry": {
@@ -3463,19 +3450,6 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "Malakoff - Guy-Môquet sud"
-            },
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    2.29683994174,
-                    48.81471318432
-                ]
-            }
-        },
-        {
-            "type": "Feature",
-            "properties": {
                 "name": "Paris - Avenue de Nogent"
             },
             "geometry": {
@@ -5932,19 +5906,6 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "Malakoff - Victor-Hugo"
-            },
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    2.30440376043,
-                    48.82154448228
-                ]
-            }
-        },
-        {
-            "type": "Feature",
-            "properties": {
                 "name": "94 - D86"
             },
             "geometry": {
@@ -6567,19 +6528,6 @@
                         2.25409333950,
                         48.83842138260
                     ]
-                ]
-            }
-        },
-        {
-            "type": "Feature",
-            "properties": {
-                "name": "Malakoff - Guy-Môquet sud"
-            },
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    2.29305266261,
-                    48.81298931956
                 ]
             }
         },


### PR DESCRIPTION
<img width="423" alt="image" src="https://user-images.githubusercontent.com/727325/82060425-af2f6a80-96c7-11ea-9c3e-bcd92255751e.png">
